### PR TITLE
[BugFix] Fix bug in caused by wrong null check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,30 @@
 - Fix bug in caused by wrong import from `class-validator`.
     - IsMin => Min
     - IsMax => Max
+
+## 0.0.11 (December 10, 2020)
+- Fix bug in caused by wrong null check.
+When `minimum` or `maximum` is set to 0, `Min` and `Max` validators are not created.
+```ts
+        pickupHour:
+          type: integer
+          minimum: 0
+          maximum: 0
+```
+
+before: 
+
+```ts
+    @IsOptional()
+    @IsInt()
+    pickupHour: number;
+```
+After:
+
+```ts
+    @IsOptional()
+    @IsInt()
+    @Min(0)
+    @Max(0)
+    pickupHour: number;
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-ts",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "OpenAPI to Typescript Code Generator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -385,11 +385,11 @@ export default function generate(spec: OpenAPIV3.Document) {
                     classValidatorDecorators.add("IsInt");
                     dec.push(cg.createDecorator(`IsInt()`));
                 }
-                if (minimum) {
+                if (minimum != null) {
                     classValidatorDecorators.add("Min");
                     dec.push(cg.createDecorator(`Min(${minimum})`));
                 }
-                if (maximum) {
+                if (maximum != null) {
                     classValidatorDecorators.add("Max");
                     dec.push(cg.createDecorator(`Max(${maximum})`));
                 }

--- a/test-files/expected-file.ts
+++ b/test-files/expected-file.ts
@@ -46,6 +46,7 @@ export type Customer = {
     email?: string;
     color?: string | null;
     age?: number;
+    pickupHour?: number;
     birthday?: string | Date;
     verified?: boolean;
     createdAt?: string | Date;
@@ -133,6 +134,14 @@ export class PostCustomerRequestBodyValidator {
     @Min(18)
     @Max(65)
     age: number;
+    /**
+     * The Age of the owner is needed here.
+     */
+    @IsOptional()
+    @IsInt()
+    @Min(0)
+    @Max(0)
+    pickupHour: number;
     /**
      * birthday
      */

--- a/test-files/pet.yaml
+++ b/test-files/pet.yaml
@@ -245,6 +245,11 @@ components:
           minimum: 18
           maximum: 65
           description: The Age of the owner is needed here.
+        pickupHour:
+          type: integer
+          minimum: 0
+          maximum: 0
+          description: The Age of the owner is needed here.
         birthday:
           type: string
           format: date


### PR DESCRIPTION
## 0.0.11 (December 10, 2020)
- Fix bug in caused by wrong null check.
When `minimum` or `maximum` is set to 0, `Min` and `Max` validators are not created.
```ts
        pickupHour:
          type: integer
          minimum: 0
          maximum: 0
```

before: 

```ts
    @IsOptional()
    @IsInt()
    pickupHour: number;
```
After:

```ts
    @IsOptional()
    @IsInt()
    @Min(0)
    @Max(0)
    pickupHour: number;
```