### PR TITLE
Fix generating enums from numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 - Fix bug when number enums are found in the specs file.
   - Target Command: `gen-agent`
 
+```yml
+    NumberEnum:
+      type: number
+      enum:
+        - 1
+        - 2
+    StringEnum:
+      type: string
+      enum:
+        - a
+        - b
+```
+
+```ts
+export type NumberEnum = 1 | 2;
+export type StringEnum = "a" | "b";
+```
+
 ## 1.0.0 (December 27, 2020)
 ### Add sub-commands:
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1 (December 27, 2020)
+- Fix bug when number enums are found in the specs file.
+  - Target Command: `gen-agent`
+
 ## 1.0.0 (December 27, 2020)
 ### Add sub-commands:
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-ts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenAPI to Typescript Code Generator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -199,7 +199,7 @@ export default function generate(spec: OpenAPIV3.Document) {
         if (schema.enum) {
             return ts.createUnionTypeNode(
                 schema.enum.map(s =>
-                    ts.createLiteralTypeNode(ts.createStringLiteral(s))
+                    ts.createLiteralTypeNode(ts.createLiteral(s))
                 )
             );
         }

--- a/test-files/expected-file.ts
+++ b/test-files/expected-file.ts
@@ -32,9 +32,13 @@ export type NewPet = {
     tag?: string;
     color?: string;
 };
+export type NumberEnum = 1 | 2;
+export type StringEnum = "a" | "b";
 export type AddPetRequestBody = {
     petName: string;
     petData?: NewPet;
+    petNumberType?: NumberEnum;
+    petStringType?: StringEnum;
 };
 export type AddPetResponseBody = Pet;
 export type GetCustomerQuery = {
@@ -103,6 +107,16 @@ export class AddPetRequestBodyValidator {
     @IsOptional()
     @IsObject()
     petData: NewPet;
+    /**
+     * petNumberType
+     */
+    @IsOptional()
+    petNumberType: NumberEnum;
+    /**
+     * petStringType
+     */
+    @IsOptional()
+    petStringType: StringEnum;
 }
 export class GetCustomerQueryValidator {
     /**

--- a/test-files/pet.yaml
+++ b/test-files/pet.yaml
@@ -292,6 +292,16 @@ components:
           format: int32
         message:
           type: string
+    NumberEnum:
+      type: number
+      enum:
+        - 1
+        - 2
+    StringEnum:
+      type: string
+      enum:
+        - a
+        - b
   requestBodies:
     PostAddPet:
       description: Pet to add to the store
@@ -311,6 +321,10 @@ components:
                 pattern: '[a-zA-Z0-9]'
               petData:
                 $ref: '#/components/schemas/NewPet'
+              petNumberType:
+                $ref: '#/components/schemas/NumberEnum'
+              petStringType:
+                $ref: '#/components/schemas/StringEnum'
 
   responses:
     PetResponseBody:


### PR DESCRIPTION
- Fix bug when number enums are found in the specs file.
  - Target Command: `gen-agent`

```yml
    NumberEnum:
      type: number
      enum:
        - 1
        - 2
    StringEnum:
      type: string
      enum:
        - a
        - b
```

```ts
export type NumberEnum = 1 | 2;
export type StringEnum = "a" | "b";
```