### PR TITLE
Allow class validator to validate array of enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 1.0.3 (January 3, 2021)
+- Allow class validator to validate array of enums.
+  - Target Command: `gen-agent`
+
+```yml
+  petListEnum:
+    type: array
+    items:
+      $ref: '#/components/schemas/StringEnum'
+```
+
+```ts
+    /**
+     * petListEnum
+     */
+    @IsOptional()
+    @IsArray()
+    @IsEnum(StringEnumEnum, { each: true })
+    petListEnum: StringEnum[];
+```
+
 ## 1.0.2 (December 30, 2020)
 - Allow generating Typescript enums for validation.
   - Target Command: `gen-agent`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-ts",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "OpenAPI to Typescript Code Generator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -409,6 +409,15 @@ export default function generate(spec: OpenAPIV3.Document) {
             case "array": {
                 classValidatorDecorators.add("IsArray");
                 dec.push(cg.createDecorator(`IsArray()`));
+                if (isReference(params.items)) {
+                    const enumNameForArray = enumRefsMap[params.items.$ref];
+                    classValidatorDecorators.add("IsEnum");
+                    dec.push(
+                        cg.createDecorator(
+                            `IsEnum(${enumNameForArray}, { each: true })`
+                        )
+                    );
+                }
                 return dec;
             }
             case "object": {

--- a/test-files/expected-file.ts
+++ b/test-files/expected-file.ts
@@ -41,6 +41,7 @@ export type AddPetRequestBody = {
     petNumberType?: NumberEnum;
     petStringType?: StringEnum;
     petExternalEnum?: PetExternalEnum;
+    petListEnum?: StringEnum[];
 };
 export type AddPetResponseBody = Pet;
 export type GetCustomerQuery = {
@@ -139,6 +140,13 @@ export class AddPetRequestBodyValidator {
     @IsOptional()
     @IsEnum(PetExternalEnumEnum)
     petExternalEnum: PetExternalEnum;
+    /**
+     * petListEnum
+     */
+    @IsOptional()
+    @IsArray()
+    @IsEnum(StringEnumEnum, { each: true })
+    petListEnum: StringEnum[];
 }
 export class GetCustomerQueryValidator {
     /**

--- a/test-files/pet.yaml
+++ b/test-files/pet.yaml
@@ -329,7 +329,10 @@ components:
                 $ref: '#/components/schemas/StringEnum'
               petExternalEnum:
                 $ref: '#/components/schemas/PetExternalEnum'
-
+              petListEnum:
+                type: array
+                items:
+                  $ref: '#/components/schemas/StringEnum'
   responses:
     PetResponseBody:
       description: pet response


### PR DESCRIPTION
## 1.0.3 (January 3, 2021)
- Allow class validator to validate array of enums.
  - Target Command: `gen-agent`

```yml
  petListEnum:
    type: array
    items:
      $ref: '#/components/schemas/StringEnum'
```

```ts
    /**
     * petListEnum
     */
    @IsOptional()
    @IsArray()
    @IsEnum(StringEnumEnum, { each: true })
    petListEnum: StringEnum[];
```