### PR TITLE
Add static check to gen-agent command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 ## 1.0.3 (January 3, 2021)
+### Target Command: `gen-agent`
+- Throw and error and exit process with schema validation error is encountered.
+- Show warning when missing required properties are found.
+
+```
+Validation Error
+Error parsing ~/open-ts/test-files/pet.yaml 
+duplicated mapping key at line 248, column -764:
+          properties:
+          ^
+```
+
+## 1.0.3 (January 3, 2021)
 - Allow class validator to validate array of enums.
   - Target Command: `gen-agent`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-ts",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "OpenAPI to Typescript Code Generator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -3,6 +3,7 @@ import * as ts from "typescript";
 import * as path from "path";
 import { OpenAPIV3 } from "openapi-types";
 import * as cg from "./ts-helpers";
+import * as logs from "../utils/logs";
 
 const verbs = [
     "GET",
@@ -197,6 +198,7 @@ export default function generate(spec: OpenAPIV3.Document) {
         }
 
         if (schema.properties || schema.additionalProperties) {
+            checkRequiredProperties(schema);
             return getTypeFromProperties(
                 schema.properties || {},
                 schema.required,
@@ -239,6 +241,15 @@ export default function generate(spec: OpenAPIV3.Document) {
         }
     }
 
+    function checkRequiredProperties(schema: OpenAPIV3.NonArraySchemaObject) {
+        const properties = schema.properties || {};
+        const all = Object.keys(properties).join(", ");
+        (schema.required || []).forEach(key => {
+            if (!(key in properties)) {
+                logs.warn(`WARNING: '${key}' is missing in '${all}'`);
+            }
+        });
+    }
     function getTypeFromProperties(
         props: {
             [prop: string]: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject;

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -1,14 +1,21 @@
 import * as SwaggerParser from "@apidevtools/swagger-parser";
 import { OpenAPIV3 } from "openapi-types";
 import * as path from "path";
+import * as logs from "../utils/logs";
 
 export async function getValidSchema(
     relPath: string
 ): Promise<OpenAPIV3.Document> {
-    await SwaggerParser.validate(path.resolve(process.cwd(), relPath));
-    const result: any = await SwaggerParser.bundle(
-        path.resolve(process.cwd(), relPath),
-        { parse: { json: true } }
-    );
-    return result;
+    try {
+        await SwaggerParser.validate(path.resolve(process.cwd(), relPath));
+        const result: any = await SwaggerParser.bundle(
+            path.resolve(process.cwd(), relPath),
+            { parse: { json: true } }
+        );
+        return result;
+    } catch (error) {
+        logs.error("Validation Error");
+        logs.log(error.message);
+        process.exit(1);
+    }
 }

--- a/src/utils/logs.ts
+++ b/src/utils/logs.ts
@@ -2,3 +2,11 @@
 export function warn(msg: string): void {
     console.warn("\x1b[33m%s\x1b[0m", msg);
 }
+
+export function error(msg: string): void {
+    console.warn("\x1b[31m%s\x1b[0m", msg);
+}
+
+export function log(msg: string): void {
+    console.log(msg);
+}


### PR DESCRIPTION
## 1.0.5 (January 8, 2021)
### Target Command: `gen-agent`
- Throw and error and exit process with schema validation error is encountered.
- Show warning when missing required properties are found.

```
Validation Error
Error parsing ~/open-ts/test-files/pet.yaml 
duplicated mapping key at line 248, column -764:
          properties:
          ^
```