### PR TITLE
Fix bug in nested object validation for arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,13 @@
 
 #### Before
 ```ts
-
+    /**
+     * petDataList
+     */
+    @IsOptional()
+    @IsArray()
+    @IsEnum(undefined, { each: true })
+    petDataList: NewPet[];
 ```
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+## 1.1.1 (February 27, 2021)
+### Target Command: `gen-agent`
+- Fix nested array check
+
+```yaml
+  petDataList:
+    type: array
+    items:
+      $ref: '#/components/schemas/NewPet'
+```
+
+#### Before
+```ts
+
+```
+
+
+#### After
+```ts
+    /**
+     * petDataList
+     */
+    @IsOptional()
+    @IsArray()
+    @ValidateNested({ each: true })
+    @Type(() => NewPetValidator)
+    petDataList: NewPet[];
+```
+
 ## 1.1.0 (January 17, 2021)
 ### Target Command: `gen-agent`
 - Allow nested object validation.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-ts",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "OpenAPI to Typescript Code Generator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test-files/expected-file.ts
+++ b/test-files/expected-file.ts
@@ -41,6 +41,7 @@ export type PetExternalEnum = number;
 export type AddPetRequestBody = {
     petName: string;
     petData?: NewPet;
+    petDataList?: NewPet[];
     inlineObject?: {
         food?: string;
     };
@@ -169,6 +170,14 @@ export class AddPetRequestBodyValidator {
     @ValidateNested()
     @Type(() => NewPetValidator)
     petData: NewPet;
+    /**
+     * petDataList
+     */
+    @IsOptional()
+    @IsArray()
+    @ValidateNested({ each: true })
+    @Type(() => NewPetValidator)
+    petDataList: NewPet[];
     /**
      * inlineObject
      */

--- a/test-files/pet.yaml
+++ b/test-files/pet.yaml
@@ -328,6 +328,10 @@ components:
                 pattern: '[a-zA-Z0-9]'
               petData:
                 $ref: '#/components/schemas/NewPet'
+              petDataList:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NewPet'
               inlineObject:
                 type: object
                 properties:


### PR DESCRIPTION
## 1.1.1 (February 27, 2021)
### Target Command: `gen-agent`
- Fix nested array check

```yaml
  petDataList:
    type: array
    items:
      $ref: '#/components/schemas/NewPet'
```

#### Before
```ts
    /**
     * petDataList
     */
    @IsOptional()
    @IsArray()
    @IsEnum(undefined, { each: true })
    petDataList: NewPet[];
```


#### After
```ts
    /**
     * petDataList
     */
    @IsOptional()
    @IsArray()
    @ValidateNested({ each: true })
    @Type(() => NewPetValidator)
    petDataList: NewPet[];
```