### PR TITLE
(proposal): Generating OpenAPI Enums as TypeScript UnionTypes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,9 @@ web_modules/
 # FuseBox cache
 .fusebox/
 
+# InteliJ Editor
+.idea
+
 # DynamoDB Local files
 .dynamodb/
 

--- a/src/lib/ts-helpers.ts
+++ b/src/lib/ts-helpers.ts
@@ -575,3 +575,37 @@ export function createEnum(name: string, values: (string | number)[]) {
         members
     );
 }
+
+export function createUnionTypeValues(
+    name: string,
+    values: (string | number)[]
+) {
+    const props = values.map(v =>
+        ts.factory.createPropertyAssignment(
+            v.toString(),
+            typeof v === "string"
+                ? ts.factory.createStringLiteral(v)
+                : ts.factory.createNumericLiteral(v)
+        )
+    );
+    return ts.factory.createVariableStatement(
+        [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+        ts.factory.createVariableDeclarationList(
+            [
+                ts.factory.createVariableDeclaration(
+                    ts.factory.createIdentifier(name),
+                    undefined,
+                    undefined,
+                    ts.factory.createAsExpression(
+                        ts.factory.createObjectLiteralExpression(props, true),
+                        ts.factory.createTypeReferenceNode(
+                            ts.factory.createIdentifier("const"),
+                            undefined
+                        )
+                    )
+                )
+            ],
+            ts.NodeFlags.Const
+        )
+    );
+}

--- a/src/lib/ts-helpers.ts
+++ b/src/lib/ts-helpers.ts
@@ -582,7 +582,7 @@ export function createUnionTypeValues(
 ) {
     const props = values.map(v =>
         ts.factory.createPropertyAssignment(
-            v.toString(),
+            typeof v === "number" ? "_" + v.toString() : v.toString(),
             typeof v === "string"
                 ? ts.factory.createStringLiteral(v)
                 : ts.factory.createNumericLiteral(v)

--- a/test-files/expected-file.ts
+++ b/test-files/expected-file.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsArray, IsInt, IsNotEmpty, Length, Matches, ValidateNested, IsEnum, ValidateIf, MinLength, IsEmail, Min, Max, IsBoolean } from "class-validator";
+import { IsOptional, IsArray, IsInt, IsNotEmpty, Length, Matches, ValidateNested, IsIn, ValidateIf, MinLength, IsEmail, Min, Max, IsBoolean } from "class-validator";
 import { Type } from "class-transformer";
 /*
  * This file is auto-generated. Do NOT modify this file manually.
@@ -35,9 +35,9 @@ export type NewPet = {
         food?: string;
     };
 };
-export type NumberEnum = number;
-export type StringEnum = string;
-export type PetExternalEnum = number;
+export type NumberEnum = typeof NumberEnum[keyof typeof NumberEnum];
+export type StringEnum = typeof StringEnum[keyof typeof StringEnum];
+export type PetExternalEnum = typeof PetExternalEnum[keyof typeof PetExternalEnum];
 export type AddPetRequestBody = {
     petName: string;
     petData?: NewPet;
@@ -49,6 +49,7 @@ export type AddPetRequestBody = {
     petStringType?: StringEnum;
     petExternalEnum?: PetExternalEnum;
     petListEnum?: StringEnum[];
+    petDirectEnum?: "x" | "y" | "z";
 };
 export type AddPetResponseBody = Pet;
 export type GetCustomerQuery = {
@@ -89,18 +90,18 @@ export type PostFileJoinRequestBody = {
         large: string;
     } | null;
 };
-enum NumberEnumEnum {
-    _1 = 1,
-    _2 = 2
-}
-enum StringEnumEnum {
-    _a = "a",
-    _b = "b"
-}
-enum PetExternalEnumEnum {
-    _1 = 1,
-    _2 = 2
-}
+export const NumberEnum = {
+    1: 1,
+    2: 2
+} as const;
+export const StringEnum = {
+    a: "a",
+    b: "b"
+} as const;
+export const PetExternalEnum = {
+    1: 1,
+    2: 2
+} as const;
 export class FindPetsQueryValidator {
     /**
      * tags to filter by
@@ -191,27 +192,33 @@ export class AddPetRequestBodyValidator {
      * petNumberType
      */
     @IsOptional()
-    @IsEnum(NumberEnumEnum)
+    @IsIn(Object.values(NumberEnum))
     petNumberType: NumberEnum;
     /**
      * petStringType
      */
     @IsOptional()
-    @IsEnum(StringEnumEnum)
+    @IsIn(Object.values(StringEnum))
     petStringType: StringEnum;
     /**
      * petExternalEnum
      */
     @IsOptional()
-    @IsEnum(PetExternalEnumEnum)
+    @IsIn(Object.values(PetExternalEnum))
     petExternalEnum: PetExternalEnum;
     /**
      * petListEnum
      */
     @IsOptional()
     @IsArray()
-    @IsEnum(StringEnumEnum, { each: true })
+    @IsIn(Object.values(StringEnum), { each: true })
     petListEnum: StringEnum[];
+    /**
+     * petDirectEnum
+     */
+    @IsOptional()
+    @IsIn(["x","y","z"])
+    petDirectEnum: "x" | "y" | "z";
 }
 export class GetCustomerQueryValidator {
     /**
@@ -292,7 +299,7 @@ export class FindPetByIdQueryValidator {
      * Language
      */
     @IsNotEmpty()
-    @IsInt
+    @IsInt()
     lang: string;
 }
 export class UpdateByIdQueryValidator {
@@ -300,13 +307,13 @@ export class UpdateByIdQueryValidator {
      * Language
      */
     @IsNotEmpty()
-    @IsInt
+    @IsInt()
     lang: string;
     /**
      * Color
      */
     @IsOptional()
-    @IsInt
+    @IsInt()
     color: string;
     /**
      * Tags List

--- a/test-files/expected-file.ts
+++ b/test-files/expected-file.ts
@@ -91,16 +91,16 @@ export type PostFileJoinRequestBody = {
     } | null;
 };
 export const NumberEnum = {
-    1: 1,
-    2: 2
+    _1: 1,
+    _2: 2
 } as const;
 export const StringEnum = {
     a: "a",
     b: "b"
 } as const;
 export const PetExternalEnum = {
-    1: 1,
-    2: 2
+    _1: 1,
+    _2: 2
 } as const;
 export class FindPetsQueryValidator {
     /**

--- a/test-files/pet.yaml
+++ b/test-files/pet.yaml
@@ -347,6 +347,12 @@ components:
                 type: array
                 items:
                   $ref: '#/components/schemas/StringEnum'
+              petDirectEnum:
+                type: string
+                enum:
+                  - x
+                  - y
+                  - z
   responses:
     PetResponseBody:
       description: pet response


### PR DESCRIPTION
# Overview
Implemented OpenAPI enum definitions to be generated as TypeScript UnionTypes instead of TypeScript Enums.
This makes it more type-safe and avoids the bad practice of Enums in TypeScript.

# Problems in the past
If you want OpenAPI to accept input only for pre-specified literals, use the [enum](https://swagger.io/docs/specification/data-models/enums/) syntax.
However, OpenAPI enums are generated as TypeScript enums.
In my opinion, it is not very safe to use TypeScript's Enum for this purpose. Here are the reasons.
- Since TypeScript automatically determines the real value in the order of member definition by sequential numbering, it is easy to be destroyed by programmer's mistake.
- Numeric enums are not type-safe.
- No tree-shaking.
- Type error even if real values are equal.
```.ts
enum EnumA {
    hoge,
    fuga
}
enum EnumB {
    hoge,
    fuga
}

const a: EnumA = 1; // OK
const b: EnumA = EnumB.hoge; // NG (!!)
const c: EnumA = 99; // OK （!!）
```
# Solution
In such a case, TypeScript Enum can be replaced by **UnionTypes**.
By using UnionTypes, primitives are compared, making them more type-safe.
Also, by using const assertion, you can define candidate values as object literals, and by using `typeof` and `keyof`, you can define UnionTypes dynamically.
It can also be safely compared with existing TypeScript defined Enums.

# Example
（Only the most important parts are excerpted.）
### Input(`api.yaml`)
```.yaml
NumberEnum:
  type: number
  enum:
    - 1
    - 2
StringEnum:
  type: string
  enum:
    - a
    - b
PetExternalEnum:
  $ref: './schemas/fileJoin.yml#/ExternalEnum'
（-- Abbreviation --）
petNumberType:
  $ref: '#/components/schemas/NumberEnum'
petStringType:
  $ref: '#/components/schemas/StringEnum'
petExternalEnum:
  $ref: '#/components/schemas/PetExternalEnum'
petListEnum:
  type: array
  items:
    $ref: '#/components/schemas/StringEnum'
petDirectEnum:
  type: string
  enum:
    - x
    - y
    - z
```
### Output(`generated.ts`)
```.ts
export type NumberEnum = typeof NumberEnum[keyof typeof NumberEnum];
export type StringEnum = typeof StringEnum[keyof typeof StringEnum];
export type PetExternalEnum = typeof PetExternalEnum[keyof typeof PetExternalEnum];
export const NumberEnum = {
    1: 1,
    2: 2
} as const;
export const StringEnum = {
    a: "a",
    b: "b"
} as const;
export const PetExternalEnum = {
    1: 1,
    2: 2
} as const;
export class AddPetRequestBodyValidator {
    /**
     * petNumberType
     */
    @IsOptional()
    @IsIn(Object.values(NumberEnum))
    petNumberType: NumberEnum;
    /**
     * petStringType
     */
    @IsOptional()
    @IsIn(Object.values(StringEnum))
    petStringType: StringEnum;
    /**
     * petExternalEnum
     */
    @IsOptional()
    @IsIn(Object.values(PetExternalEnum))
    petExternalEnum: PetExternalEnum;
    /**
     * petListEnum
     */
    @IsOptional()
    @IsArray()
    @IsIn(Object.values(StringEnum), { each: true })
    petListEnum: StringEnum[];
    /**
     * petDirectEnum
     */
    @IsOptional()
    @IsIn(["x","y","z"])
    petDirectEnum: "x" | "y" | "z";
}
```