### PR TITLE
(convert-enums) Generate OpenAPI enums from Typescript object literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,60 @@
+## 1.3.0 (September 6, 2021)
+### Target Command: `convert-enums`
+- Add generation of openAPI enums as yaml file from all object literals annotated by `const` keyword in a given directory.
+
+#### Input
+```ts
+const ObjectEnumStr = {
+    Foo: "FOO",
+    Bar: "BAR"
+} as const;
+
+const ObjectEnumNum = {
+    One: 1,
+    Bar: 2
+} as const;
+
+const ObjectEnumWithFunc = {
+    func: () => 1
+} as const;
+
+const ObjectEnumWithBool = {
+    bool: true
+} as const;
+
+const MixedObjectEnum = {
+    Foo: "FOO",
+    One: 1
+} as const;
+
+const ObjectEnumEmpty = {} as const;
+
+/* open-ts: ignore-convert-enums */
+const ObjectEnumIgnored = {
+    Baz: "BAZ",
+    Qux: "QUX"
+} as const;
+
+const ObjectEnumMutable = {
+    Quux: "QUUX",
+    quuz: "QUUZ"
+};
+```
+
+#### Output
+```yaml
+ObjectEnumNum:
+  type: number
+  enum:
+    - 1
+    - 2
+ObjectEnumStr:
+  type: string
+  enum:
+    - FOO
+    - BAR
+```
+
 ## 1.2.0 (June 17, 2021)
 ### Target Command: `gen-agent`
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,18 @@ npm install -g open-ts
 ```
 
 ## Usage
-1/ API Agent
+### 1/ API Agent
+#### Usage
 ```
 open-ts gen-agent <path/to/your-openapi-specs-file.yml> <path/to/generated/your-ts-file.ts>
 ```
 
-2/ OpenAPI enums
+### 2/ OpenAPI enums
+This command parses files of the `<path/to/dir>` and generated OpenAPI specs enums for Typescript enums and Object literals annotated with `const` keyword. To exclude an object declaration, use the leading comment:
+```ts
+/* open-ts: ignore-convert-enums */
+```
+#### Usage
 ```
 open-ts convert-enums <path/to/dir> <path/to/generated/your-yaml-file.yml>
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-ts",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "OpenAPI to Typescript Code Generator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/commands/convertEnums.ts
+++ b/src/lib/commands/convertEnums.ts
@@ -5,6 +5,8 @@ import * as _ from "lodash";
 import * as yaml from "js-yaml";
 import * as logs from "../../utils/logs";
 
+const IGNORE_ENUM_COMMENT = "/* open-ts: ignore-convert-enums */";
+
 export function warn(file: string, enumName: string, msg: string): void {
     logs.warn(
         `   [WARNING] Unsupported enum '${enumName}' detected in:  ${file} \n    ${msg}`
@@ -55,12 +57,84 @@ export async function convertEnums(
         }
         return tempName;
     }
+
     files.forEach(tsFile => {
         const program = ts.createProgram([tsFile], {});
         const source = program.getSourceFile(tsFile);
         const checker = program.getTypeChecker();
 
+        function getNodeLeadingComments(node: ts.Node): string[] {
+            const commentRanges = ts.getLeadingCommentRanges(
+                source.getFullText(),
+                node.getFullStart()
+            );
+            if (commentRanges?.length) {
+                const commentStrings: string[] = commentRanges.map(r =>
+                    source.getFullText().slice(r.pos, r.end)
+                );
+                return commentStrings;
+            }
+            return [];
+        }
+        function checkIsObjectLiteralDefinition(node: ts.Node) {
+            const isObject = node.kind === ts.SyntaxKind.VariableDeclaration;
+            if (!isObject) return;
+            const isConst = node.getLastToken().getText() === "const";
+            if (!isConst) return;
+            const isIgnored = getNodeLeadingComments(node.parent).includes(
+                IGNORE_ENUM_COMMENT
+            );
+            if (isIgnored) {
+                return;
+            }
+            const enumNode = node as ts.VariableDeclaration;
+            const enumName = getEnumName(enumNode.name.getText());
+            let supportedType = "";
+            const values: (string | number)[] = [];
+            const nodes = enumNode
+                .getChildAt(2)
+                .getChildAt(0)
+                .getChildAt(1)
+                .getChildren()
+                .filter(c => c.kind === ts.SyntaxKind.PropertyAssignment)
+                .map(c => c.getChildAt(2));
+            for (const node of nodes) {
+                const value: number | string | null = (() => {
+                    if (node.kind === ts.SyntaxKind.NumericLiteral) {
+                        return +node.getText();
+                    } else if (node.kind === ts.SyntaxKind.StringLiteral) {
+                        return JSON.parse(node.getText());
+                    }
+                    return null;
+                })();
+                if (value === null) {
+                    warn(
+                        tsFile,
+                        enumNode.name.getText(),
+                        "Unsupported Type: " + node.getText()
+                    );
+                    return;
+                }
+                supportedType = supportedType || typeof value;
+                if (supportedType !== typeof value) {
+                    warn(
+                        tsFile,
+                        enumNode.name.getText(),
+                        "Mixed Types: " + supportedType + " and " + typeof value
+                    );
+                    return;
+                }
+                values.push(value);
+            }
+            if (values.length === 0) return;
+            output.push({
+                name: enumName,
+                type: supportedType,
+                items: values
+            });
+        }
         function traverseNode(node: ts.Node) {
+            checkIsObjectLiteralDefinition(node);
             if (node.kind === ts.SyntaxKind.EnumDeclaration) {
                 const enumNode = node as ts.EnumDeclaration;
                 const supportedType = getSupportedType(enumNode);

--- a/test-files/enums/object-literals.ts
+++ b/test-files/enums/object-literals.ts
@@ -1,0 +1,35 @@
+const ObjectEnumStr = {
+    Foo: "FOO",
+    Bar: "BAR"
+} as const;
+
+const ObjectEnumNum = {
+    One: 1,
+    Bar: 2
+} as const;
+
+const ObjectEnumWithFunc = {
+    func: () => 1
+} as const;
+
+const ObjectEnumWithBool = {
+    bool: true
+} as const;
+
+const MixedObjectEnum = {
+    Foo: "FOO",
+    One: 1
+} as const;
+
+const ObjectEnumEmpty = {} as const;
+
+/* open-ts: ignore-convert-enums */
+const ObjectEnumIgnored = {
+    Baz: "BAZ",
+    Qux: "QUX"
+} as const;
+
+const ObjectEnumMutable = {
+    Quux: "QUUX",
+    quuz: "QUUZ"
+};

--- a/test-files/expected-enum-file.yml
+++ b/test-files/expected-enum-file.yml
@@ -7,6 +7,16 @@ Numbers:
   enum:
     - 1
     - 2
+ObjectEnumNum:
+  type: number
+  enum:
+    - 1
+    - 2
+ObjectEnumStr:
+  type: string
+  enum:
+    - FOO
+    - BAR
 SpecialString:
   type: string
   enum:


### PR DESCRIPTION
### Target Command: `convert-enums`
- Add generation of openAPI enums as yaml file from all object literals annotated by `const` keyword in a given directory.

#### Input
```ts
const ObjectEnumStr = {
    Foo: "FOO",
    Bar: "BAR"
} as const;

const ObjectEnumNum = {
    One: 1,
    Bar: 2
} as const;

const ObjectEnumWithFunc = {
    func: () => 1
} as const;

const ObjectEnumWithBool = {
    bool: true
} as const;

const MixedObjectEnum = {
    Foo: "FOO",
    One: 1
} as const;

const ObjectEnumEmpty = {} as const;

/* open-ts: ignore-convert-enums */
const ObjectEnumIgnored = {
    Baz: "BAZ",
    Qux: "QUX"
} as const;

const ObjectEnumMutable = {
    Quux: "QUUX",
    quuz: "QUUZ"
};
```

#### Output
```yaml
ObjectEnumNum:
  type: number
  enum:
    - 1
    - 2
ObjectEnumStr:
  type: string
  enum:
    - FOO
    - BAR
```