### PR TITLE
Fix/enum nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.1 (October 19, 2021)
+### Target Command: `gen-agent`
+- `$ref` is not validated correctly when it has `nullable: true`
+
 ## 1.3.0 (September 6, 2021)
 ### Target Command: `convert-enums`
 - Add generation of openAPI enums as yaml file from all object literals annotated by `const` keyword in a given directory.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-ts",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "OpenAPI to Typescript Code Generator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -383,6 +383,7 @@ export default function generate(spec: OpenAPIV3.Document) {
             | OpenAPIV3.ReferenceObject,
         propName: string,
         isRequired: boolean,
+        isNullable: boolean,
         enumName?: string
     ) {
         const params = resolveIfRef(property);
@@ -397,7 +398,7 @@ export default function generate(spec: OpenAPIV3.Document) {
             dec.push(cg.createDecorator("IsOptional()"));
         }
 
-        if (!isOptional && isNullable(params)) {
+        if (!isOptional && isNullable) {
             classValidatorDecorators.add("ValidateIf");
             dec.push(
                 cg.createDecorator(`ValidateIf(o => o.${propName} !== null)`)
@@ -593,6 +594,7 @@ export default function generate(spec: OpenAPIV3.Document) {
                 modifiers: [ts.createModifier(ts.SyntaxKind.ExportKeyword)],
                 members: Object.keys(properties).map(p => {
                     const property = properties[p];
+                    const isNullable = (property as any)?.nullable;
                     const obj = resolveIfRef(property);
                     return cg.addComment(
                         cg.createProperty(p, {
@@ -600,6 +602,7 @@ export default function generate(spec: OpenAPIV3.Document) {
                                 property,
                                 p,
                                 requiredMap[p],
+                                isNullable,
                                 isReference(property)
                                     ? enumRefsMap[property.$ref]
                                     : undefined

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -594,7 +594,6 @@ export default function generate(spec: OpenAPIV3.Document) {
                 modifiers: [ts.createModifier(ts.SyntaxKind.ExportKeyword)],
                 members: Object.keys(properties).map(p => {
                     const property = properties[p];
-                    const isNullable = (property as any)?.nullable;
                     const obj = resolveIfRef(property);
                     return cg.addComment(
                         cg.createProperty(p, {
@@ -602,7 +601,7 @@ export default function generate(spec: OpenAPIV3.Document) {
                                 property,
                                 p,
                                 requiredMap[p],
-                                isNullable,
+                                isNullable(property),
                                 isReference(property)
                                     ? enumRefsMap[property.$ref]
                                     : undefined

--- a/test-files/expected-file.ts
+++ b/test-files/expected-file.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsArray, IsInt, IsNotEmpty, Length, Matches, ValidateNested, IsIn, ValidateIf, MinLength, IsEmail, Min, Max, IsBoolean } from "class-validator";
+import { IsOptional, IsArray, IsInt, IsNotEmpty, Length, Matches, ValidateNested, ValidateIf, IsIn, MinLength, IsEmail, Min, Max, IsBoolean } from "class-validator";
 import { Type } from "class-transformer";
 /*
  * This file is auto-generated. Do NOT modify this file manually.
@@ -45,7 +45,7 @@ export type AddPetRequestBody = {
     inlineObject?: {
         food?: string;
     };
-    petNumberType?: NumberEnum;
+    petNumberType: NumberEnum | null;
     petStringType?: StringEnum;
     petExternalEnum?: PetExternalEnum;
     petListEnum?: StringEnum[];
@@ -191,7 +191,8 @@ export class AddPetRequestBodyValidator {
     /**
      * petNumberType
      */
-    @IsOptional()
+    @IsNotEmpty()
+    @ValidateIf(o => o.petNumberType !== null)
     @IsIn(Object.values(NumberEnum))
     petNumberType: NumberEnum;
     /**

--- a/test-files/pet.yaml
+++ b/test-files/pet.yaml
@@ -319,6 +319,7 @@ components:
             type: object
             required:
               - petName
+              - petNumberType
             properties:
               petName:
                 type:
@@ -339,6 +340,7 @@ components:
                     type: string
               petNumberType:
                 $ref: '#/components/schemas/NumberEnum'
+                nullable: true
               petStringType:
                 $ref: '#/components/schemas/StringEnum'
               petExternalEnum:


### PR DESCRIPTION
## 1.3.1 (October 19, 2021)
### Target Command: `gen-agent`
- `$ref` is not validated correctly when it has `nullable: true`
