### PR TITLE
Lock dependency to avoid version mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.4 (Dec 21, 2022)
+### Target Command: all
+- Lock typescript version to `~4.7.4` as `~4.9.4` seems to have breaking changes.
+
 ## 1.3.3 (July 22, 2022)
 ### Target Command: all
 - Fix bug introduced in previous version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-ts",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "OpenAPI to Typescript Code Generator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -15,7 +15,7 @@
     "fs-extra": "^9.0.1",
     "js-yaml": "^3.14.1",
     "json-schema-to-typescript": "^8.2.0",
-    "typescript": "^4.7.4"
+    "typescript": "~4.7.4"
   },
   "scripts": {
     "clean": "del build && del node_modules",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2526,7 +2526,7 @@ type@^2.0.0:
   resolved "https://registry.yarnpkg.com/type/-/type-2.0.0.tgz#5f16ff6ef2eb44f260494dae271033b29c09a9c3"
   integrity sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==
 
-typescript@^4.7.4:
+typescript@~4.7.4:
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==


### PR DESCRIPTION
## 1.3.4 (Dec 21, 2022)
### Target Command: all
- Lock typescript version to `~4.7.4` as `~4.9.4` seems to have breaking changes.